### PR TITLE
np.average to np.ma.average

### DIFF
--- a/sushi/__init__.py
+++ b/sushi/__init__.py
@@ -272,7 +272,7 @@ def average_shifts(events):
     events = [e for e in events if not e.linked]
     shifts = [x.shift for x in events]
     weights = [1 - x.diff for x in events]
-    avg = np.average(shifts, weights=weights)
+    avg = np.ma.average(shifts, weights=weights)
     for e in events:
         e.set_shift(avg, e.diff)
     return avg


### PR DESCRIPTION
Use np.ma.average instead of np.average to avoid division by zero error (not sure what exactly in source  file causes it, i suspect  very short chapters or something like this)