### PR TITLE
hacky fix for missing segment near the end of dst file

### DIFF
--- a/sushi/__init__.py
+++ b/sushi/__init__.py
@@ -427,7 +427,12 @@ def calculate_shifts(src_stream, dst_stream, groups_list, normal_window, max_win
             log_uncommitted(group_state, new_time - original_time, left_side_time - original_time,
                             right_side_time - original_time, start_offset)
 
-        shift = new_time - original_time
+        if new_time is not None:
+            shift = new_time - original_time
+        else:
+            shift = -1000000
+            diff = 0.00001
+
         if not terminate:
             # we aren't back on track yet - add this group to uncommitted
             group_state.update({"shift": shift, "diff": diff})


### PR DESCRIPTION
sushi doesnt not handle missing segments in destination file vert well (it ouputs corresponding subtitles  with a pretty random timings), but there is a particularly  bad case when missing segment is near the end of dst fiel and is longer than matching segment at the very end - it causes sushi to crash with attempt to perform operations on NoneType.

This is a very hacky fix for this particular case

It would be better to fix handling of missing segments properly, but i do not understand sushi code to attempt that.