### PR TITLE
fix ass error handling (remnants of python2)

### DIFF
--- a/sushi/subs.py
+++ b/sushi/subs.py
@@ -235,7 +235,7 @@ class AssScript(ScriptBase):
                         try:
                             parse_function(line)
                         except Exception as e:
-                            raise SushiError("That's some invalid ASS script: {0} [line {1}]".format(e.message, line_idx))
+                            raise SushiError("That's some invalid ASS script: {0} [line {1}]".format(e, line_idx))
         except IOError:
             raise SushiError("Script {0} not found".format(path))
         return cls(script_info, styles, events, other_sections)


### PR DESCRIPTION
Exception has no attribute message in python3 